### PR TITLE
Correct name of output CSS file for move

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-const fse = require('fs-extra')
-const dotenv = require('dotenv')
+const fse = require('fs-extra');
+const dotenv = require('dotenv');
 
 // Load your local .env file into process.env
-dotenv.config()
+dotenv.config();
 
 fse
-  .copy('./obsidian-night-owl-theme.css', process.env.DESTINATION)
+  .copy('./obsidian.css', process.env.DESTINATION)
   .then(() => console.log('Destination: CSS file copied successfully!'))
-  .catch(error => console.error(error))
+  .catch((error) => console.error(error));


### PR DESCRIPTION
When trying `yarn move` for the first time I got this error:

```json
yarn run v1.22.5
$ node index.js
[Error: ENOENT: no such file or directory, stat './obsidian-night-owl-theme.css'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: './obsidian-night-owl-theme.css'
}
✨  Done in 0.24s.
```